### PR TITLE
Explicit reference to python 3.5

### DIFF
--- a/kitana.py
+++ b/kitana.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python3.5
 import hashlib
 import os
 import io


### PR DESCRIPTION
Allow to select the right version of python.