### PR TITLE
Optimize Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,21 @@
+# Saved sessions
 data/sessions/*
+# Compiled files
 static/css/*
-__pycache__/*
-venv/*
+__pycache__
+# Unused by runtime
+.*
+README.md
+LICENSE*
+Dockerfile*
+CHANGELOG
+# Windows
+util/win32.py
+requirements_win32.txt
+# Virtual Environment
+venv
+Lib
+Scripts
+Include
+share
+tcl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,29 @@
 # Use an official Python runtime as a parent image
-FROM python:3.8-slim
+FROM python:3.8-alpine
 
 # Set the working directory to /app
 WORKDIR /app
-ARG DEBIAN_FRONTEND=noninteractive
-RUN ln -s /usr/bin/dpkg-split /usr/sbin/dpkg-split
-RUN ln -s /usr/bin/dpkg-deb /usr/sbin/dpkg-deb
-RUN ln -s /bin/tar /usr/sbin/tar
-RUN ln -s /bin/rm /usr/sbin/rm
-RUN apt-get update \
-    && apt-get install -y \
-        apt-utils \
-        gcc \
-        g++ \
-        build-essential libssl-dev libffi-dev python-dev python-pip python3-dev cargo  \
-    --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt /app
-RUN python -m pip install -U pip
+# Add Kitana files not filtered by .dockerignore to the image
+COPY . .
 
-# Install any needed packages specified in requirements.txt
-RUN pip install --trusted-host pypi.python.org -r requirements.txt \
-    && apt-get purge -y --auto-remove gcc g++ build-essential libssl-dev libffi-dev python-dev python-pip python3-dev cargo
+# We chain the following steps to create a single layer, reducing image size
+# - Install packages needed to run and compile
+# - Install and compile required Python packgages
+# - Remove packages needed only for compiling
+RUN apk add -U --repository=http://dl-cdn.alpinelinux.org/alpine/v3.13/main \
+    gcc g++ musl-dev openssl-dev libffi-dev 'python3-dev=~3.8' cargo build-base \
+    libstdc++ \
+    && pip install --trusted-host pypi.python.org -r requirements.txt \
+    && apk del -r --purge \
+    gcc g++ musl-dev openssl-dev libffi-dev python3-dev cargo build-base \
+    && rm /var/cache/apk/*
 
-# Copy the current directory contents into the container at /app
-COPY . /app
-
-# Make port 80 available to the world outside this container
+# Expose the port
 EXPOSE 31337
 
-# Define environment variable
-#ENV NAME World
-
+# Store session tokens here
 VOLUME /app/data
 
-# Run app.py when the container launches
+# Run kitana.py when the container launches
 ENTRYPOINT ["python", "kitana.py"]


### PR DESCRIPTION
As a result of this, the image is now 90% smaller (80.4MB as opposed to 847MB)
- Switched to Alpine-based Python image for a smaller initial footprint (~1/3 the size of `slim`)
- Significantly reduced the steps to build the image, resulting in less layers created and smaller final filesize
- Documented and added more entries to `.dockerignore`