### PR TITLE
Bump cherrypy to 18.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cryptography<3.5
-cherrypy==18.6.1
+cherrypy==18.8.0
 requests==2.26.0
 xmltodict==0.12.0
 libsass==0.21.0


### PR DESCRIPTION
This will bring in https://github.com/cherrypy/cheroot/pull/401 which reduces the idle CPU usage for me from 20% to under 1%.
Worked locally with a custom build docker image.